### PR TITLE
add demo for making properties required with `@Required`

### DIFF
--- a/docs/code/example/example-default-values-primitive-fields-02.kt
+++ b/docs/code/example/example-default-values-primitive-fields-02.kt
@@ -1,0 +1,23 @@
+// This file was automatically generated from default-values.md by Knit tool. Do not edit.
+@file:Suppress("PackageDirectoryMismatch", "unused")
+package dev.adamko.kxstsgen.example.exampleDefaultValuesPrimitiveFields02
+
+import kotlinx.serialization.*
+import dev.adamko.kxstsgen.*
+
+@Serializable
+data class ContactDetails(
+  @Required
+  val name: String,
+  @Required
+  val email: String?,
+  @Required
+  val active: Boolean = true,
+  @Required
+  val phoneNumber: String? = null,
+)
+
+fun main() {
+  val tsGenerator = KxsTsGenerator()
+  println(tsGenerator.generate(ContactDetails.serializer()))
+}

--- a/docs/code/test/DefaultValuesTest.kt
+++ b/docs/code/test/DefaultValuesTest.kt
@@ -84,4 +84,31 @@ class DefaultValuesTest : FunSpec({
       actual.shouldTypeScriptCompile(caseName)
     }
   }
+
+  context("ExampleDefaultValuesPrimitiveFields02") {
+    val caseName = testCase.name.testName
+
+    val actual = captureOutput(caseName) {
+      dev.adamko.kxstsgen.example.exampleDefaultValuesPrimitiveFields02.main()
+    }.normalizeJoin()
+
+    test("expect actual matches TypeScript") {
+      actual.shouldBe(
+        // language=TypeScript
+        """
+          |export interface ContactDetails {
+          |  name: string;
+          |  email: string | null;
+          |  active: boolean;
+          |  phoneNumber: string | null;
+          |}
+        """.trimMargin()
+        .normalize()
+      )
+    }
+
+    test("expect actual compiles").config(tags = tsCompile) {
+      actual.shouldTypeScriptCompile(caseName)
+    }
+  }
 })

--- a/docs/customising-output.md
+++ b/docs/customising-output.md
@@ -7,7 +7,7 @@
 
 * [Introduction](#introduction)
   * [Overriding output](#overriding-output)
-  * [Override nullable elements](#override-nullable-elements)
+  * [Override nullable properties](#override-nullable-properties)
   * [Override both nullable and non-nullable descriptors](#override-both-nullable-and-non-nullable-descriptors)
 
 <!--- END -->
@@ -101,7 +101,7 @@ export interface Item {
 
 <!--- TEST TS_COMPILE_OFF -->
 
-### Override nullable elements
+### Override nullable properties
 
 Even though UInt is nullable, it should be overridden by the UInt defined in `descriptorOverrides`.
 

--- a/docs/default-values.md
+++ b/docs/default-values.md
@@ -8,6 +8,7 @@
   * [Default values](#default-values)
   * [Nullable values](#nullable-values)
   * [Default and nullable](#default-and-nullable)
+  * [Override optional properties](#override-optional-properties)
 
 <!--- END -->
 
@@ -102,6 +103,49 @@ export interface ContactDetails {
   email: string | null;
   active?: boolean;
   phoneNumber?: string | null;
+}
+```
+
+<!--- TEST -->
+
+### Override optional properties
+
+Properties with default values can be set as required using the Kotlinx Serialization annotation,
+[`@kotlinx.serialization.Required`](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization/-required/)
+.
+
+For demonstration purposes, let's see what happens when `@Required` is added to all properties.
+
+```kotlin
+@Serializable
+data class ContactDetails(
+  @Required
+  val name: String,
+  @Required
+  val email: String?,
+  @Required
+  val active: Boolean = true,
+  @Required
+  val phoneNumber: String? = null,
+)
+
+fun main() {
+  val tsGenerator = KxsTsGenerator()
+  println(tsGenerator.generate(ContactDetails.serializer()))
+}
+```
+
+> You can get the full code [here](./code/example/example-default-values-primitive-fields-02.kt).
+
+`active` and `phoneNumber` are now required properties. Note that `@Required` had no effect
+on `name` or `email`. Because they do not have default values, they were already required.
+
+```typescript
+export interface ContactDetails {
+  name: string;
+  email: string | null;
+  active: boolean;
+  phoneNumber: string | null;
 }
 ```
 

--- a/docs/default-values.md
+++ b/docs/default-values.md
@@ -138,7 +138,7 @@ fun main() {
 > You can get the full code [here](./code/example/example-default-values-primitive-fields-02.kt).
 
 `active` and `phoneNumber` are now required properties. Note that `@Required` had no effect
-on `name` or `email`. Because they do not have default values, they were already required.
+on `name` or `email`; because they do not have default values, they were already required.
 
 ```typescript
 export interface ContactDetails {


### PR DESCRIPTION
Adding some docs to demo how `@Required` can be used to make properties required.

cc @nschulzke https://github.com/adamko-dev/kotlinx-serialization-typescript-generator/pull/47

