### PR TITLE
run tests on main branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
   workflow_call:
+  push:
+    branches:
+      - main
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"


### PR DESCRIPTION
run tests on main branch, otherwise the Gradle cache doesn't update