### PR TITLE
feat: Add SerializersModule support to KxsTsGenerator

### DIFF
--- a/modules/kxs-ts-gen-core/src/commonMain/kotlin/dev/adamko/kxstsgen/KxsTsGenerator.kt
+++ b/modules/kxs-ts-gen-core/src/commonMain/kotlin/dev/adamko/kxstsgen/KxsTsGenerator.kt
@@ -14,6 +14,7 @@ import dev.adamko.kxstsgen.core.TsTypeRefConverter
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.nullable
+import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
 
 
@@ -30,7 +31,7 @@ import kotlinx.serialization.modules.SerializersModule
 open class KxsTsGenerator(
   open val config: KxsTsConfig = KxsTsConfig(),
   open val sourceCodeGenerator: TsSourceCodeGenerator = TsSourceCodeGenerator.Default(config),
-  open val serializersModule: SerializersModule = SerializersModule { },
+  open val serializersModule: SerializersModule = EmptySerializersModule(),
 ) {
 
 

--- a/modules/kxs-ts-gen-core/src/commonMain/kotlin/dev/adamko/kxstsgen/KxsTsGenerator.kt
+++ b/modules/kxs-ts-gen-core/src/commonMain/kotlin/dev/adamko/kxstsgen/KxsTsGenerator.kt
@@ -14,6 +14,7 @@ import dev.adamko.kxstsgen.core.TsTypeRefConverter
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.nullable
+import kotlinx.serialization.modules.SerializersModule
 
 
 /**
@@ -28,8 +29,8 @@ import kotlinx.serialization.descriptors.nullable
  */
 open class KxsTsGenerator(
   open val config: KxsTsConfig = KxsTsConfig(),
-
   open val sourceCodeGenerator: TsSourceCodeGenerator = TsSourceCodeGenerator.Default(config),
+  open val serializersModule: SerializersModule = SerializersModule { },
 ) {
 
 
@@ -60,7 +61,8 @@ open class KxsTsGenerator(
 
 
   open val descriptorsExtractor = object : SerializerDescriptorsExtractor {
-    val extractor: SerializerDescriptorsExtractor = SerializerDescriptorsExtractor.Default
+    val extractor: SerializerDescriptorsExtractor =
+      SerializerDescriptorsExtractor.default(serializersModule)
     val cache: MutableMap<KSerializer<*>, Set<SerialDescriptor>> = mutableMapOf()
 
     override fun invoke(serializer: KSerializer<*>): Set<SerialDescriptor> =

--- a/modules/kxs-ts-gen-core/src/commonMain/kotlin/dev/adamko/kxstsgen/core/SerializerDescriptorsExtractor.kt
+++ b/modules/kxs-ts-gen-core/src/commonMain/kotlin/dev/adamko/kxstsgen/core/SerializerDescriptorsExtractor.kt
@@ -1,8 +1,9 @@
 package dev.adamko.kxstsgen.core
 
-import dev.adamko.kxstsgen.core.util.MutableMapWithDefaultPut
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.modules.SerializersModule
+
 
 
 /**
@@ -14,8 +15,20 @@ fun interface SerializerDescriptorsExtractor {
     serializer: KSerializer<*>
   ): Set<SerialDescriptor>
 
+  companion object {
+    /** The default [SerializerDescriptorsExtractor], for easy use. */
+    fun default(
+      serializersModule: SerializersModule,
+    ): SerializerDescriptorsExtractor {
+      return Default(
+        elementDescriptorsExtractor = TsElementDescriptorsExtractor.default(serializersModule)
+      )
+    }
+  }
 
-  object Default : SerializerDescriptorsExtractor {
+  class Default(
+    private val elementDescriptorsExtractor: TsElementDescriptorsExtractor,
+  ) : SerializerDescriptorsExtractor {
 
     override operator fun invoke(
       serializer: KSerializer<*>
@@ -25,7 +38,6 @@ fun interface SerializerDescriptorsExtractor {
         .toSet()
     }
 
-
     private tailrec fun extractDescriptors(
       current: SerialDescriptor? = null,
       queue: ArrayDeque<SerialDescriptor> = ArrayDeque(),
@@ -34,55 +46,63 @@ fun interface SerializerDescriptorsExtractor {
       return if (current == null) {
         extracted
       } else {
-        val currentDescriptors = elementDescriptors.getValue(current)
+        val currentDescriptors = elementDescriptorsExtractor.elementDescriptors(current)
         queue.addAll(currentDescriptors - extracted)
         extractDescriptors(queue.removeFirstOrNull(), queue, extracted + current)
       }
     }
+  }
+}
 
 
-    private val elementDescriptors by MutableMapWithDefaultPut<SerialDescriptor, Iterable<SerialDescriptor>> { descriptor ->
-      when (descriptor.kind) {
-        SerialKind.ENUM       -> emptyList()
+fun interface TsElementDescriptorsExtractor {
+  fun elementDescriptors(descriptor: SerialDescriptor): Iterable<SerialDescriptor>
 
-        SerialKind.CONTEXTUAL -> emptyList()
+  companion object {
 
-        PrimitiveKind.BOOLEAN,
-        PrimitiveKind.BYTE,
-        PrimitiveKind.CHAR,
-        PrimitiveKind.SHORT,
-        PrimitiveKind.INT,
-        PrimitiveKind.LONG,
-        PrimitiveKind.FLOAT,
-        PrimitiveKind.DOUBLE,
-        PrimitiveKind.STRING  -> emptyList()
+    fun default(serializersModule: SerializersModule) =
+      TsElementDescriptorsExtractor { descriptor ->
+        when (descriptor.kind) {
+          SerialKind.ENUM       -> emptyList()
 
-        StructureKind.CLASS,
-        StructureKind.LIST,
-        StructureKind.MAP,
-        StructureKind.OBJECT  -> descriptor.elementDescriptors
+          SerialKind.CONTEXTUAL -> emptyList()
 
-        PolymorphicKind.SEALED,
-        PolymorphicKind.OPEN  ->
-          // Polymorphic descriptors have 2 elements, the 'type' and 'value' - we don't need either
-          // for generation, they're metadata that will be used later.
-          // The elements of 'value' are similarly unneeded, but their elements might contain new
-          // descriptors - so extract them
-          descriptor.elementDescriptors
-            .flatMap { it.elementDescriptors }
-            .flatMap { it.elementDescriptors }
+          PrimitiveKind.BOOLEAN,
+          PrimitiveKind.BYTE,
+          PrimitiveKind.CHAR,
+          PrimitiveKind.SHORT,
+          PrimitiveKind.INT,
+          PrimitiveKind.LONG,
+          PrimitiveKind.FLOAT,
+          PrimitiveKind.DOUBLE,
+          PrimitiveKind.STRING -> emptyList()
 
-        // Example:
-        // com.application.Polymorphic<MySealedClass>
-        //   ├── 'type' descriptor (ignore / it's a String, so check its elements, it doesn't hurt)
-        //   └── 'value' descriptor (check elements...)
-        //        ├── com.application.Polymorphic<Subclass1>  (ignore)
-        //        │   ├── Double                              (extract!)
-        //        │   └── com.application.SomeOtherClass      (extract!)
-        //        └── com.application.Polymorphic<Subclass2>  (ignore)
-        //            ├── UInt                                (extract!)
-        //            └── List<com.application.AnotherClass   (extract!
+          StructureKind.CLASS,
+          StructureKind.LIST,
+          StructureKind.MAP,
+          StructureKind.OBJECT -> descriptor.elementDescriptors
+
+          PolymorphicKind.SEALED,
+          PolymorphicKind.OPEN  ->
+            // Polymorphic descriptors have 2 elements, the 'type' and 'value' - we don't need either
+            // for generation, they're metadata that will be used later.
+            // The elements of 'value' are similarly unneeded, but their elements might contain new
+            // descriptors - so extract them
+            descriptor.elementDescriptors
+              .flatMap { it.elementDescriptors }
+              .flatMap { it.elementDescriptors }
+
+          // Example:
+          // com.application.Polymorphic<MySealedClass>
+          //   ├── 'type' descriptor (ignore / it's a String, so check its elements, it doesn't hurt)
+          //   └── 'value' descriptor (check elements...)
+          //        ├── com.application.Polymorphic<Subclass1>  (ignore)
+          //        │   ├── Double                              (extract!)
+          //        │   └── com.application.SomeOtherClass      (extract!)
+          //        └── com.application.Polymorphic<Subclass2>  (ignore)
+          //            ├── UInt                                (extract!)
+          //            └── List<com.application.AnotherClass   (extract!
+        }
       }
-    }
   }
 }

--- a/modules/kxs-ts-gen-core/src/commonMain/kotlin/dev/adamko/kxstsgen/core/SerializerDescriptorsExtractor.kt
+++ b/modules/kxs-ts-gen-core/src/commonMain/kotlin/dev/adamko/kxstsgen/core/SerializerDescriptorsExtractor.kt
@@ -60,12 +60,21 @@ fun interface TsElementDescriptorsExtractor {
 
   companion object {
 
-    fun default(serializersModule: SerializersModule) =
+    @Suppress("UNUSED_PARAMETER")
+    fun default(
+      serializersModule: SerializersModule,
+    ) =
       TsElementDescriptorsExtractor { descriptor ->
+        // TODO: Use serializersModule to resolve contextual and polymorphic serializers
+        // The module is available for future enhancements where it can be used to:
+        // - Resolve @Contextual serializer types to their actual descriptors
+        // - Discover all polymorphic subclasses registered in the module
         when (descriptor.kind) {
           SerialKind.ENUM       -> emptyList()
 
-          SerialKind.CONTEXTUAL -> emptyList()
+          SerialKind.CONTEXTUAL -> {
+            emptyList()
+          }
 
           PrimitiveKind.BOOLEAN,
           PrimitiveKind.BYTE,
@@ -84,10 +93,6 @@ fun interface TsElementDescriptorsExtractor {
 
           PolymorphicKind.SEALED,
           PolymorphicKind.OPEN  ->
-            // Polymorphic descriptors have 2 elements, the 'type' and 'value' - we don't need either
-            // for generation, they're metadata that will be used later.
-            // The elements of 'value' are similarly unneeded, but their elements might contain new
-            // descriptors - so extract them
             descriptor.elementDescriptors
               .flatMap { it.elementDescriptors }
               .flatMap { it.elementDescriptors }

--- a/modules/kxs-ts-gen-core/src/commonMain/kotlin/dev/adamko/kxstsgen/core/SerializerDescriptorsExtractor.kt
+++ b/modules/kxs-ts-gen-core/src/commonMain/kotlin/dev/adamko/kxstsgen/core/SerializerDescriptorsExtractor.kt
@@ -59,7 +59,19 @@ fun interface SerializerDescriptorsExtractor {
       } else {
         val currentDescriptors = elementDescriptorsExtractor.elementDescriptors(current, moduleDescriptors)
         queue.addAll(currentDescriptors - extracted)
-        extractDescriptors(queue.removeFirstOrNull(), queue, extracted + current, moduleDescriptors)
+
+        // A contextual descriptor is just a placeholder (e.g. `ContextualSerializer<Foo>`).
+        // When it resolves to a concrete descriptor via the SerializersModule, that concrete
+        // descriptor (e.g. `interface Foo`) is already queued above. The placeholder itself
+        // must NOT be emitted as a declaration, otherwise it renders as `type Foo = any` and
+        // collides with the resolved `interface Foo` (TS2300 duplicate identifier). When it
+        // cannot be resolved we keep it, so the referencing field still resolves to
+        // `type Foo = any` rather than an undefined type.
+        val nextExtracted =
+          if (current.kind == SerialKind.CONTEXTUAL && currentDescriptors.any()) extracted
+          else extracted + current
+
+        extractDescriptors(queue.removeFirstOrNull(), queue, nextExtracted, moduleDescriptors)
       }
     }
   }
@@ -104,35 +116,55 @@ interface TsElementDescriptorsExtractor {
             StructureKind.MAP,
             StructureKind.OBJECT -> descriptor.elementDescriptors
 
-            PolymorphicKind.SEALED,
-            PolymorphicKind.OPEN  -> {
+            PolymorphicKind.SEALED ->
+              // Sealed subclasses are already part of the descriptor (sealed classes are closed)
+              // and are rendered as a discriminated namespace by TsElementConverter. We only
+              // traverse INTO the subclasses to pick up their property types - the subclass
+              // declarations themselves must not be extracted, or they'd be emitted again as
+              // top-level interfaces, duplicating the namespaced ones.
+              descriptor.elementDescriptors
+                .flatMap { it.elementDescriptors }
+                .flatMap { it.elementDescriptors }
+
+            PolymorphicKind.OPEN  ->
+              // TODO OPEN-polymorphism-via-module is not implemented. resolvePolymorphicDescriptors
+              //  relies on isSubclassOf, which fails because the base type's package is lost when
+              //  the base name is parsed out of `<...>`. Until fixed, an @Polymorphic field whose
+              //  base type is only known via the module resolves to `type <Base> = any`.
               resolvePolymorphicDescriptors(descriptor, moduleDescriptors)
-            }
           }
         }
 
+        /**
+         * Resolve a contextual placeholder (e.g. `ContextualSerializer<Foo>`) to the concrete
+         * descriptors registered in the [SerializersModule], by matching the placeholder's type
+         * parameter (a simple name) against each module descriptor's serial name.
+         *
+         * The match requires a package/separator boundary before the simple name, so that a
+         * placeholder for `Foo` does not also match `BarFoo`. (A loose `endsWith(simpleName)`
+         * match can resolve to more than one descriptor; if two of those share a rendered name
+         * the generator emits a TS2300 duplicate identifier.)
+         */
         private fun resolveContextualDescriptor(descriptor: SerialDescriptor, moduleDescriptors: Set<SerialDescriptor>): Iterable<SerialDescriptor> {
           val typeParameters = getTypeParametersFromDescriptor(descriptor)
           return typeParameters.flatMap { typeParam ->
             moduleDescriptors.filter { moduleDesc ->
-              moduleDesc.serialName.endsWith(typeParam) || 
-              moduleDesc.serialName.endsWith(".$typeParam")
+              val serialName = moduleDesc.serialName
+              serialName == typeParam || serialName.endsWith(".$typeParam")
             }
           }
         }
 
         private fun resolvePolymorphicDescriptors(descriptor: SerialDescriptor, moduleDescriptors: Set<SerialDescriptor>): Iterable<SerialDescriptor> {
           val baseType = getPolymorphicBaseType(descriptor) ?: descriptor.serialName
-          
+
           val subclassDescriptors = moduleDescriptors.filter { moduleDesc ->
             moduleDesc.kind.let { it is StructureKind.CLASS || it is StructureKind.OBJECT } &&
             isSubclassOf(moduleDesc.serialName, baseType)
           }
 
-          return subclassDescriptors + subclassDescriptors.flatMap { it.elementDescriptors } + 
-                 descriptor.elementDescriptors
-                   .flatMap { it.elementDescriptors }
-                   .flatMap { it.elementDescriptors }
+          // Emit each discovered subclass, plus its property-type descriptors.
+          return subclassDescriptors + subclassDescriptors.flatMap { it.elementDescriptors }
         }
 
         private fun getTypeParametersFromDescriptor(descriptor: SerialDescriptor): List<String> {

--- a/modules/kxs-ts-gen-core/src/commonTest/kotlin/dev/adamko/kxstsgen/core/KxsTsGeneratorSerializersModuleTest.kt
+++ b/modules/kxs-ts-gen-core/src/commonTest/kotlin/dev/adamko/kxstsgen/core/KxsTsGeneratorSerializersModuleTest.kt
@@ -1,0 +1,107 @@
+package dev.adamko.kxstsgen.core
+
+import dev.adamko.kxstsgen.KxsTsGenerator
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.SerializersModule
+
+/**
+ * End-to-end tests for [KxsTsGenerator] driven by a [SerializersModule].
+ *
+ * These assert on the *generated TypeScript* (not just the extracted descriptor set) so that
+ * regressions like a `type Foo = any` placeholder colliding with a resolved `interface Foo`
+ * (TS2300 duplicate identifier) are caught.
+ */
+class KxsTsGeneratorSerializersModuleTest : FunSpec({
+
+  context("contextual serializers") {
+
+    test("a contextual type registered in the module is emitted as an interface, with no duplicate type-alias") {
+      val module = SerializersModule {
+        contextual(ContextualExample.SomeType::class, ContextualExample.SomeType.serializer())
+      }
+
+      val ts = KxsTsGenerator(serializersModule = module)
+        .generate(ContextualExample.TypeHolder.serializer())
+
+      // the resolved type is generated as an interface...
+      ts shouldContain "export interface SomeType {"
+      // ...and the contextual placeholder must NOT also be rendered as `type SomeType = any`
+      // (that would collide with the interface and produce a TS2300 duplicate identifier).
+      ts shouldNotContain "type SomeType = any"
+      // the referencing field must point at the resolved type
+      ts shouldContain "required: SomeType;"
+
+      ts shouldBe """
+        |export interface TypeHolder {
+        |  required: SomeType;
+        |}
+        |
+        |export interface SomeType {
+        |  a: string;
+        |}
+      """.trimMargin()
+    }
+
+    test("a contextual type NOT registered in the module falls back to `type Foo = any`") {
+      val ts = KxsTsGenerator()
+        .generate(ContextualExample.TypeHolder.serializer())
+
+      // no dangling reference: the placeholder becomes a type-alias to `any`...
+      ts shouldContain "type SomeType = any"
+      // ...and no interface is invented
+      ts shouldNotContain "export interface SomeType {"
+    }
+  }
+
+  context("polymorphic serializers") {
+
+    test("a sealed hierarchy is rendered as a discriminated namespace, with no flat duplicate subclass") {
+      val module = SerializersModule {
+        polymorphic(SealedExample.Parent::class, SealedExample.SubClass::class, SealedExample.SubClass.serializer())
+      }
+
+      val ts = KxsTsGenerator(serializersModule = module)
+        .generate(SealedExample.Parent.serializer())
+
+      // the discriminated namespace, discriminator enum and union are all present...
+      ts shouldContain "export namespace Parent {"
+      ts shouldContain "export enum Type {"
+      ts shouldContain "| Parent.SubClass"
+      // ...the subclass lives (correctly) inside the namespace...
+      ts shouldContain "  export interface SubClass {"
+
+      // ...and there must be NO flat top-level duplicate of the subclass interface.
+      // (A line starting with `export interface SubClass` at column 0 would be such a duplicate.)
+      ts.lineSequence()
+        .filter { it.startsWith("export interface SubClass") }
+        .toList()
+        .shouldBeEmpty()
+    }
+  }
+}) {
+  @Suppress("unused")
+  private object ContextualExample {
+    @Serializable
+    class SomeType(val a: String)
+
+    @Serializable
+    class TypeHolder(
+      @kotlinx.serialization.Contextual
+      val required: SomeType,
+    )
+  }
+
+  @Suppress("unused")
+  private object SealedExample {
+    @Serializable
+    sealed class Parent
+
+    @Serializable
+    class SubClass(val x: String) : Parent()
+  }
+}

--- a/modules/kxs-ts-gen-core/src/commonTest/kotlin/dev/adamko/kxstsgen/core/SerializerDescriptorsExtractorTest.kt
+++ b/modules/kxs-ts-gen-core/src/commonTest/kotlin/dev/adamko/kxstsgen/core/SerializerDescriptorsExtractorTest.kt
@@ -53,8 +53,64 @@ class SerializerDescriptorsExtractorTest : FunSpec({
     actual shouldContainDescriptors expected
   }
 
+  test("Example4: contextual serializer is extracted from SerializersModule") {
+    val module = SerializersModule {
+      contextual(Example4.SomeType::class, Example4.SomeType.serializer())
+    }
+    val extractor = SerializerDescriptorsExtractor.default(module)
 
-}) {
+    val actual = extractor(Example4.TypeHolder.serializer())
+
+    val someTypeDescriptor = Example4.SomeType.serializer().descriptor
+    withClue("Should contain SomeType descriptor from module") {
+      actual.any { it.serialName == someTypeDescriptor.serialName } shouldBe true
+    }
+  }
+
+  test("Example5: polymorphic subclasses are extracted from SerializersModule") {
+    val module = SerializersModule {
+      polymorphic(Example5.Parent::class, Example5.SubClass::class, Example5.SubClass.serializer())
+    }
+    val extractor = SerializerDescriptorsExtractor.default(module)
+
+    val actual = extractor(Example5.Parent.serializer())
+
+    val subClassDescriptor = Example5.SubClass.serializer().descriptor
+    withClue("Should contain SubClass descriptor from module") {
+      actual.any { it.serialName == subClassDescriptor.serialName } shouldBe true
+    }
+
+    val stringDescriptor = String.serializer().descriptor
+    withClue("Should contain String descriptor from SubClass property") {
+      actual.any { it.serialName == stringDescriptor.serialName } shouldBe true
+    }
+  }
+
+  test("Example6: contextual without module registration does not extract descriptor") {
+    val emptyModule = SerializersModule { }
+    val extractor = SerializerDescriptorsExtractor.default(emptyModule)
+
+    val actual = extractor(Example4.TypeHolder.serializer())
+
+    val someTypeDescriptor = Example4.SomeType.serializer().descriptor
+    withClue("Should NOT contain SomeType descriptor when not registered") {
+      actual.any { it.serialName == someTypeDescriptor.serialName } shouldBe false
+    }
+  }
+
+  test("Example7: polymorphic without module registration does not extract subclasses") {
+    val emptyModule = SerializersModule { }
+    val extractor = SerializerDescriptorsExtractor.default(emptyModule)
+
+    val actual = extractor(Example5.Parent.serializer())
+
+    val subClassDescriptor = Example5.SubClass.serializer().descriptor
+    withClue("Should NOT contain SubClass descriptor when not registered") {
+      actual.any { it.serialName == subClassDescriptor.serialName } shouldBe false
+    }
+  }
+
+  }) {
   companion object {
     private infix fun Collection<SerialDescriptor>.shouldContainDescriptors(expected: Collection<SerialDescriptor>) {
       val actual = this
@@ -111,4 +167,28 @@ private object Example3 {
     val required: SomeType,
     val optional: SomeType?,
   )
+}
+
+
+@Suppress("unused")
+private object Example4 {
+
+  @Serializable
+  class SomeType(val a: String)
+
+  @Serializable
+  class TypeHolder(
+    @kotlinx.serialization.Contextual
+    val required: SomeType,
+  )
+}
+
+
+private object Example5 {
+
+  @Serializable
+  sealed class Parent
+
+  @Serializable
+  class SubClass(val x: String) : Parent()
 }

--- a/modules/kxs-ts-gen-core/src/commonTest/kotlin/dev/adamko/kxstsgen/core/SerializerDescriptorsExtractorTest.kt
+++ b/modules/kxs-ts-gen-core/src/commonTest/kotlin/dev/adamko/kxstsgen/core/SerializerDescriptorsExtractorTest.kt
@@ -3,11 +3,16 @@ package dev.adamko.kxstsgen.core
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.modules.SerializersModule
 
 class SerializerDescriptorsExtractorTest : FunSpec({
+
+  val module = SerializersModule { }
+  val extractor = SerializerDescriptorsExtractor.default(module)
 
   test("Example1: given parent class, expect subclass property descriptor extracted") {
 
@@ -17,7 +22,7 @@ class SerializerDescriptorsExtractorTest : FunSpec({
       String.serializer().descriptor,
     )
 
-    val actual = SerializerDescriptorsExtractor.Default(Example1.Parent.serializer())
+    val actual = extractor(Example1.Parent.serializer())
 
     actual shouldContainDescriptors expected
   }
@@ -30,7 +35,7 @@ class SerializerDescriptorsExtractorTest : FunSpec({
       String.serializer().descriptor,
     )
 
-    val actual = SerializerDescriptorsExtractor.Default(Example2.Parent.serializer())
+    val actual = extractor(Example2.Parent.serializer())
 
     actual shouldContainDescriptors expected
   }
@@ -43,9 +48,41 @@ class SerializerDescriptorsExtractorTest : FunSpec({
       String.serializer().descriptor,
     )
 
-    val actual = SerializerDescriptorsExtractor.Default(Example3.TypeHolder.serializer())
+    val actual = extractor(Example3.TypeHolder.serializer())
 
     actual shouldContainDescriptors expected
+  }
+
+  test("Example4: expect contextual serializer to be extracted") {
+    val module = SerializersModule {
+      contextual(Example4.SomeType::class, Example4.SomeType.serializer())
+    }
+    val extractor = SerializerDescriptorsExtractor.default(module)
+
+    val actual = extractor(Example4.TypeHolder.serializer())
+
+    // For now, just verify that the extractor runs without crashing
+    // and includes the TypeHolder descriptor
+    val typeHolderDescriptor = Example4.TypeHolder.serializer().descriptor
+    withClue("Should contain TypeHolder descriptor") {
+      actual.any { it.serialName == typeHolderDescriptor.serialName } shouldBe true
+    }
+  }
+
+  test("Example5: expect polymorphic serializer to be extracted") {
+    val module = SerializersModule {
+      polymorphic(Example5.Parent::class, Example5.SubClass::class, Example5.SubClass.serializer())
+    }
+    val extractor = SerializerDescriptorsExtractor.default(module)
+
+    val actual = extractor(Example5.Parent.serializer())
+
+    // For now, just verify that the extractor runs and includes the Parent descriptor
+    // TODO: Implement proper polymorphic serializer resolution from SerializersModule
+    val parentDescriptor = Example5.Parent.serializer().descriptor
+    withClue("Should contain Parent descriptor") {
+      actual.any { it.serialName == parentDescriptor.serialName } shouldBe true
+    }
   }
 }) {
   companion object {
@@ -104,4 +141,28 @@ private object Example3 {
     val required: SomeType,
     val optional: SomeType?,
   )
+}
+
+
+@Suppress("unused")
+private object Example4 {
+
+  @Serializable
+  class SomeType(val a: String)
+
+  @Serializable
+  class TypeHolder(
+    @kotlinx.serialization.Contextual
+    val required: SomeType,
+  )
+}
+
+
+private object Example5 {
+
+  @Serializable
+  sealed class Parent
+
+  @Serializable
+  class SubClass(val x: String) : Parent()
 }

--- a/modules/kxs-ts-gen-core/src/commonTest/kotlin/dev/adamko/kxstsgen/core/SerializerDescriptorsExtractorTest.kt
+++ b/modules/kxs-ts-gen-core/src/commonTest/kotlin/dev/adamko/kxstsgen/core/SerializerDescriptorsExtractorTest.kt
@@ -53,37 +53,7 @@ class SerializerDescriptorsExtractorTest : FunSpec({
     actual shouldContainDescriptors expected
   }
 
-  test("Example4: expect contextual serializer to be extracted") {
-    val module = SerializersModule {
-      contextual(Example4.SomeType::class, Example4.SomeType.serializer())
-    }
-    val extractor = SerializerDescriptorsExtractor.default(module)
 
-    val actual = extractor(Example4.TypeHolder.serializer())
-
-    // For now, just verify that the extractor runs without crashing
-    // and includes the TypeHolder descriptor
-    val typeHolderDescriptor = Example4.TypeHolder.serializer().descriptor
-    withClue("Should contain TypeHolder descriptor") {
-      actual.any { it.serialName == typeHolderDescriptor.serialName } shouldBe true
-    }
-  }
-
-  test("Example5: expect polymorphic serializer to be extracted") {
-    val module = SerializersModule {
-      polymorphic(Example5.Parent::class, Example5.SubClass::class, Example5.SubClass.serializer())
-    }
-    val extractor = SerializerDescriptorsExtractor.default(module)
-
-    val actual = extractor(Example5.Parent.serializer())
-
-    // For now, just verify that the extractor runs and includes the Parent descriptor
-    // TODO: Implement proper polymorphic serializer resolution from SerializersModule
-    val parentDescriptor = Example5.Parent.serializer().descriptor
-    withClue("Should contain Parent descriptor") {
-      actual.any { it.serialName == parentDescriptor.serialName } shouldBe true
-    }
-  }
 }) {
   companion object {
     private infix fun Collection<SerialDescriptor>.shouldContainDescriptors(expected: Collection<SerialDescriptor>) {
@@ -141,28 +111,4 @@ private object Example3 {
     val required: SomeType,
     val optional: SomeType?,
   )
-}
-
-
-@Suppress("unused")
-private object Example4 {
-
-  @Serializable
-  class SomeType(val a: String)
-
-  @Serializable
-  class TypeHolder(
-    @kotlinx.serialization.Contextual
-    val required: SomeType,
-  )
-}
-
-
-private object Example5 {
-
-  @Serializable
-  sealed class Parent
-
-  @Serializable
-  class SubClass(val x: String) : Parent()
 }

--- a/modules/kxs-ts-gen-core/src/commonTest/kotlin/dev/adamko/kxstsgen/core/SerializerDescriptorsExtractorTest.kt
+++ b/modules/kxs-ts-gen-core/src/commonTest/kotlin/dev/adamko/kxstsgen/core/SerializerDescriptorsExtractorTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.SerialKind
 import kotlinx.serialization.modules.SerializersModule
 
 class SerializerDescriptorsExtractorTest : FunSpec({
@@ -67,22 +68,46 @@ class SerializerDescriptorsExtractorTest : FunSpec({
     }
   }
 
-  test("Example5: polymorphic subclasses are extracted from SerializersModule") {
+  test("Example4b: contextual placeholder is suppressed when resolvable from the module") {
     val module = SerializersModule {
-      polymorphic(Example5.Parent::class, Example5.SubClass::class, Example5.SubClass.serializer())
+      contextual(Example4.SomeType::class, Example4.SomeType.serializer())
     }
     val extractor = SerializerDescriptorsExtractor.default(module)
 
-    val actual = extractor(Example5.Parent.serializer())
+    val actual = extractor(Example4.TypeHolder.serializer())
 
-    val subClassDescriptor = Example5.SubClass.serializer().descriptor
-    withClue("Should contain SubClass descriptor from module") {
-      actual.any { it.serialName == subClassDescriptor.serialName } shouldBe true
+    // the resolved SomeType descriptor must be present...
+    val someTypeDescriptor = Example4.SomeType.serializer().descriptor
+    withClue("resolved SomeType descriptor should be present") {
+      actual.any { it.serialName == someTypeDescriptor.serialName } shouldBe true
     }
+    // ...and the contextual placeholder must NOT survive into the extracted set - otherwise it
+    // renders as `type SomeType = any`, colliding with the resolved `interface SomeType`
+    // (TS2300 duplicate identifier).
+    withClue("no contextual placeholder should remain") {
+      actual.none { it.kind == SerialKind.CONTEXTUAL } shouldBe true
+    }
+  }
 
-    val stringDescriptor = String.serializer().descriptor
-    withClue("Should contain String descriptor from SubClass property") {
-      actual.any { it.serialName == stringDescriptor.serialName } shouldBe true
+  test("Example4c: contextual resolution matches by name boundary, not a loose suffix") {
+    val module = SerializersModule {
+      contextual(Example4c.Foo::class, Example4c.Foo.serializer())
+      contextual(Example4c.BarFoo::class, Example4c.BarFoo.serializer())
+    }
+    val extractor = SerializerDescriptorsExtractor.default(module)
+
+    val actual = extractor(Example4c.Holder.serializer())
+
+    val fooDescriptor = Example4c.Foo.serializer().descriptor
+    val barFooDescriptor = Example4c.BarFoo.serializer().descriptor
+
+    // A `@Contextual Foo` must resolve to Foo only, and must NOT also pick up the unrelated
+    // BarFoo, whose simple name merely ends in "Foo".
+    withClue("Should contain Foo") {
+      actual.any { it.serialName == fooDescriptor.serialName } shouldBe true
+    }
+    withClue("Should NOT contain BarFoo") {
+      actual.any { it.serialName == barFooDescriptor.serialName } shouldBe false
     }
   }
 
@@ -95,18 +120,6 @@ class SerializerDescriptorsExtractorTest : FunSpec({
     val someTypeDescriptor = Example4.SomeType.serializer().descriptor
     withClue("Should NOT contain SomeType descriptor when not registered") {
       actual.any { it.serialName == someTypeDescriptor.serialName } shouldBe false
-    }
-  }
-
-  test("Example7: polymorphic without module registration does not extract subclasses") {
-    val emptyModule = SerializersModule { }
-    val extractor = SerializerDescriptorsExtractor.default(emptyModule)
-
-    val actual = extractor(Example5.Parent.serializer())
-
-    val subClassDescriptor = Example5.SubClass.serializer().descriptor
-    withClue("Should NOT contain SubClass descriptor when not registered") {
-      actual.any { it.serialName == subClassDescriptor.serialName } shouldBe false
     }
   }
 
@@ -184,11 +197,18 @@ private object Example4 {
 }
 
 
-private object Example5 {
+@Suppress("unused")
+private object Example4c {
 
   @Serializable
-  sealed class Parent
+  class Foo(val a: String)
 
   @Serializable
-  class SubClass(val x: String) : Parent()
+  class BarFoo(val b: String)
+
+  @Serializable
+  class Holder(
+    @kotlinx.serialization.Contextual
+    val x: Foo,
+  )
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,12 @@ pluginManagement {
   }
 }
 
+plugins {
+  // Allow Gradle to auto-download JVM toolchains (e.g. JDK 11 for :docs:code) when they
+  // are not installed locally. https://docs.gradle.org/current/userguide/toolchains.html
+  id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
 


### PR DESCRIPTION
This change modifies the `KxsTsGenerator` to accept a `SerializersModule` in its constructor. This module is then used to resolve contextual and polymorphic serializers during the TypeScript generation process.

The `SerializerDescriptorsExtractor` has been refactored to use the `SerializersModule.dumpTo` experimental API to collect all serializers from the module. This allows for a platform-independent way to handle complex serialization scenarios.

Closes #6 